### PR TITLE
Fix spelling errors on login.html

### DIFF
--- a/draw_hw/accounts/templates/accounts/login.html
+++ b/draw_hw/accounts/templates/accounts/login.html
@@ -77,7 +77,7 @@
                     {% csrf_token %}
                     
                     <br><br>
-                    <h2>Click to the button bellow and follow the instruction.</h2>
+                    <h2>Click the button bellow and follow the instruction.</h2>
                     <br><br>
 
                     <input type="submit" name="submitF" id="submitF" value="Reset"> <br><br><br>

--- a/draw_hw/templates/registration/login.html
+++ b/draw_hw/templates/registration/login.html
@@ -77,7 +77,7 @@
                     {% csrf_token %}
                     
                     <br><br>
-                    <h2>Click to the button bellow and follow the instruction.</h2>
+                    <h2>Click the button bellow and follow the instruction.</h2>
                     <br><br>
 
                     <input type="submit" name="submitF" id="submitF" value="Reset"> <br><br><br>


### PR DESCRIPTION
I fixed the spelling error in login.html page in templates and acccounts/templates.